### PR TITLE
Fix single image evaluation for single batch

### DIFF
--- a/multipoint/utils/evaluation.py
+++ b/multipoint/utils/evaluation.py
@@ -24,7 +24,7 @@ def compute_detector_metrics(net, dataloader, device, config):
                            config['nms'],
                            config['detection_threshold'])
 
-        out = list(map(lambda p, k: compute_tp_fp_dist(p,k), pred.squeeze().cpu(), data['keypoints'].cpu()))
+        out = list(map(lambda p, k: compute_tp_fp_dist(p,k), pred[:,0].cpu(), data['keypoints'].cpu()))
 
         for item in out:
             tp.append(item[0].tolist())


### PR DESCRIPTION
The squeeze of the prediction caused issues for the evaluation with a batch size of 1. The proposed solution fixed this bug by preserving the batch dimension.